### PR TITLE
Remove hard coded path to zpyi.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ If you feel lazy, this works too:
 curl https://raw.githubusercontent.com/sakshamsharma/zpyi/master/install_script.sh | bash
 ```
 
-Or if you make use of [antigen](https://github.com/zsh-users/antigen) (and if you don't you should check it out it's awesome)
+Or if you make use of [antigen](https://github.com/zsh-users/antigen) 
 ```
-antigen bundle https://github.com/peteches/zpyi zpyi.zsh
+antigen bundle https://github.com/sakshamsharma/zpyi zpyi.zsh
 ```
 
 # TODO

--- a/README.md
+++ b/README.md
@@ -77,5 +77,10 @@ If you feel lazy, this works too:
 curl https://raw.githubusercontent.com/sakshamsharma/zpyi/master/install_script.sh | bash
 ```
 
+Or if you make use of [antigen](https://github.com/zsh-users/antigen) (and if you don't you should check it out it's awesome)
+```
+antigen bundle https://github.com/peteches/zpyi zpyi.zsh
+```
+
 # TODO
 * Add support for querying for missing packages

--- a/zpyi.zsh
+++ b/zpyi.zsh
@@ -17,7 +17,22 @@ command_not_found_handler() {
     # Need to put to background
     echo -e "$1" > $INPUT_PIPE &
 
-    python ~/.zpyi/zpyi.py $INPUT_PIPE
+    # Arcane zsh invokation alert
+    #
+    # ${(%):-%x} below will
+    # be interpolated as
+    # the absolute path to the file
+    # this line is written in.
+
+    # see man zshmisc for this and other
+    # sanity testing obscure zsh magic
+
+    # This allows the zpyi repo to be checked out
+    # and sourced from anywhere in the filesystem
+    # and still work.
+    zpyi_dir=$(dirname ${(%):-%x})
+
+    python ${zpyi_dir}/zpyi.py $INPUT_PIPE
 
     # Optionally uncomment the below lines if
     # you do not use python so often


### PR DESCRIPTION
So I love this idea, and I'm looking forwrd to taking it through it's paces.
But, I use antigen to manage all my external zsh plugins, themes and scripts. Antigen clones the repo to `~/.antigen/<encoded url of repo>` then sources a given file from inside the repo.

However as there is a hard coded directory in `zpyi.zsh` and as it is not in the expected location the python fallback fails.

I have utilised a smidgin of zsh's crazy variable interpolation stuff to locate the `zpyi.zsh` file and then worked out where the `zpyi.py` script is.

I have also updated the README to include an antigen command to load zpyi.
