### PR TITLE
Allow custom import modules through environment variables

### DIFF
--- a/zpyi.py
+++ b/zpyi.py
@@ -9,6 +9,11 @@ import sys
 import os
 from math import *
 
+if 'ZPYI_IMPORTS' in os.environ:
+    for module in os.environ['ZPYI_IMPORTS'].split(','):
+        _module = __import__(module, globals(), locals())
+        globals().update(_module.__dict__)
+
 def cleanup():
     try:
         os.unlink(sys.argv[1])


### PR DESCRIPTION
Very neat project, I added a feature you might be interested in:

```
orf@mean-lean-dev-machine:~|⇒  export ZPYI_IMPORTS=requests,urllib
orf@mean-lean-dev-machine:~|⇒  'urlopen' 
<function urlopen at 0x7f64abeef398>
```

One problem is you can't seem to pass strings to functions. Any way around this?
