### PR TITLE
Check for existence of `zpyi.py`.

### DIFF
--- a/zpyi.zsh
+++ b/zpyi.zsh
@@ -47,11 +47,15 @@ command_not_found_handler() {
     # and still work.
     zpyi_dir=$(dirname ${(%):-%x})
 
-    if [ "$#" -ne 1 ]; then
-        python ${zpyi_dir}/zpyi.py $INPUT_PIPE $ARGS_PIPE
-        rm $ARGS_PIPE
+    if [[ -a ${zpyi_dir}/zpyi.py ]]; then
+        if [ "$#" -ne 1 ]; then
+            python ${zpyi_dir}/zpyi.py $INPUT_PIPE $ARGS_PIPE
+            rm $ARGS_PIPE
+        else
+            python ${zpyi_dir}/zpyi.py $INPUT_PIPE
+        fi
     else
-        python ${zpyi_dir}/zpyi.py $INPUT_PIPE
+        echo "Couldn't find ${zpyi_dir}/zpyi.py...Downloading again might help."
     fi
 
     # Optionally uncomment the below lines if


### PR DESCRIPTION
Presently when an `Uninstallation` is done and than a non-zsh command is executed(say "2+3") it outputs that python couldn't find `zpyi.py`(because a `namedpipe` is still being created and exist in
`.cache`) file.It may be better(ofcourse author's call) to do a firsthand-check
for `zpyi.py` and if it exists than only run the script(i.e. `zpyi.py`).
In this PR, I have added a "placeholder" statement in `else` block which
can replaced by, may be, something more appropriate.
P.S: Wasn't sure whether you take "long" or "one-line" commit messages, if it's worth merging than I can surely  shorten the commit message. 