### PR TITLE
Adds support for querying packages

### DIFF
--- a/import.sh
+++ b/import.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+    # Checks for archlinux
+    OS_INFO=$(cat /etc/os-release | grep -i 'archlinux')
+    if [ "$?" -eq 0 ]; then
+        pkg_srch=$(pacman -Ss | grep ${1})
+
+        if [ "$?" -eq 0 ]; then
+            sudo pacman -Syu  ${1} 2> /dev/null
+        else
+            exit 1
+        fi
+    fi
+
+    # Checks for Ubuntu
+    OS_INFO=$(cat /etc/os-release | grep -i 'Ubuntu')
+    if [ "$?" -eq 0 ]; then
+        pkg_srch=$(apt-get list | grep ${1})
+
+        if [ "$?" -eq 0 ]; then
+            sudo apt-get install -y ${1} 2> /dev/null
+        else
+            exit 1
+        fi
+    fi
+
+    # Checks for fedora
+    OS_INFO=$(cat /etc/os-release | grep -i 'fedora')
+    if [ "$?" -eq 0 ]; then
+        pkg_srch=$(yum list  | grep ${1})
+
+        if [ "$?" -eq 0 ]; then
+            sudo yum update && yum install -y ${1} 2> /dev/null
+        else
+            exit 1
+        fi
+    fi
+
+    # Will Check for gentoo
+    # OS_INFO=$(cat /etc/os-release | grep -i 'gentoo')
+    # if [ "$?" -eq 0 ]; then
+    #     emerge -s ${1}
+    #
+    #     if [ "$?" -eq 0 ]; then
+    #         emerge  ${1} 2> /dev/null
+    #     else
+    #         exit 1
+    #     fi
+    # fi

--- a/zpyi.py
+++ b/zpyi.py
@@ -8,6 +8,7 @@
 import sys
 import os
 from math import *
+import subprocess
 
 if 'ZPYI_IMPORTS' in os.environ:
     for module in os.environ['ZPYI_IMPORTS'].split(','):
@@ -38,10 +39,17 @@ code = ([ i for i in codestr if i.strip() ])
 # Use try catch to return only after cleanup
 try:
     if len(code) == 1 and not code[0].startswith('print'):
+
+        # Call to import script to check if it's a package and installable
+        _import_call_result = subprocess.call(['./import.sh', code[0]])
+
+        # If the above call exits with non-zero status than the usual eval
+        # is called so that
         # Commands like:
         # '1+2'
-        # Also should display output
-        print (eval(code[0]))
+        # Also display output
+        if _import_call_result != 0:
+            print (eval(code[0]))
     else:
         # Bigger commands
         # 'a = 2

--- a/zpyi.zsh
+++ b/zpyi.zsh
@@ -47,11 +47,15 @@ command_not_found_handler() {
     # and still work.
     zpyi_dir=$(dirname ${(%):-%x})
 
-    if [ "$#" -ne 1 ]; then
-        python ${zpyi_dir}/zpyi.py $INPUT_PIPE $ARGS_PIPE
-        rm $ARGS_PIPE
+    if [[ -a ${zpyi_dir}/zpyi.py ]]; then
+        if [ "$#" -ne 1 ]; then
+            python ${zpyi_dir}/zpyi.py $INPUT_PIPE $ARGS_PIPE
+            rm $ARGS_PIPE
+        else
+            python ${zpyi_dir}/zpyi.py $INPUT_PIPE
+        fi
     else
-        python ${zpyi_dir}/zpyi.py $INPUT_PIPE
+        echo "Couldn't find ${zpyi_dir}/zpyi.py...Downloading again might help."
     fi
 
     # Optionally uncomment the below lines if


### PR DESCRIPTION
- Makes a system call to a `import.sh` script that finds the distro than does the import if possible and if not than everything occurs normally...
- Tested for `archlinux` but if you like the implementation than I could do testing for other distros too...and also add support for may-be `open-suse`.
- There is a possibility of  a feature that you could revert, even, from the installation prompt(but that I don't think would be of much practical value as...how many valid python scripts match package names?)
- So views...